### PR TITLE
Make 1 stripe the default

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -64,7 +64,7 @@
     </entry>
     <entry name="maxStripes" type="Int">
       <label>The maximum number of rows (in a horizontal-orientation containment, i.e. panel) or columns (in a vertical-orientation containment) to layout task buttons in.</label>
-      <default>2</default>
+      <default>1</default>
       <min>1</min>
     </entry>
     <entry name="maxButtonLength" type="Int">


### PR DESCRIPTION
Upstream change from Plasma 5.27 (https://invent.kde.org/plasma/plasma-desktop/-/commit/4d737a3cd22fdba3bcfdc6b44cf2cb8402f510b8) which workarounds the issue when user centers "Task Manager" on the panel using Spacers (https://bugs.kde.org/show_bug.cgi?id=460911)